### PR TITLE
Feature: make window border configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ use {
       -- left_ratio = 0.2,
       -- top_ratio = 0.03,
       -- width_ratio = 0.67,
-      -- height_ratio = 0.9
+      -- height_ratio = 0.9,
+      -- border = 'double',
     }
     vim.keymap.set('n', '<CR>', function ()
       vim.cmd('NeoZoomToggle')
@@ -44,4 +45,3 @@ Change `<CR>` to whatever shortcut you like~
 ### DEMO
 
 will be uploaded
-

--- a/lua/neo-zoom.lua
+++ b/lua/neo-zoom.lua
@@ -22,6 +22,7 @@ function M.setup(opt)
   M.height_ratio = opt.height_ratio ~= nil and opt.height_ratio or 0.9
   M.top_ratio = opt.top_ratio ~= nil and opt.top_ratio or 0.03
   M.left_ratio = opt.left_ratio ~= nil and opt.left_ratio or 0.32
+  M.border = opt.border ~= nil and opt.border or 'double'
 end
 
 function M.neo_zoom()
@@ -57,7 +58,7 @@ function M.neo_zoom()
     width = math.ceil(editor_width * M.width_ratio + 0.5),
     focusable = true,
     zindex = 5,
-    border = 'double',
+    border = M.border,
   })
 
   pin_to_80_percent_height()


### PR DESCRIPTION
This PR allows the user to set the window border type. For example in my config I'd like to use a `single` border for the zoomed window.

Thanks for the plugin!