### PR TITLE
Return boolean from neo_zoom()

### DIFF
--- a/lua/neo-zoom.lua
+++ b/lua/neo-zoom.lua
@@ -49,7 +49,7 @@ function M.neo_zoom()
         and vim.api.nvim_win_get_config(0).relative == '')
       or _in_table(M.exclude_filetypes, vim.bo.filetype)
     ) then
-    return
+    return false
   end
   local uis = vim.api.nvim_list_uis()[1]
   local editor_width = uis.width
@@ -66,7 +66,7 @@ function M.neo_zoom()
     
     M.WIN_ON_ENTER = nil
     M.FLOAT_WIN = nil
-    return
+    return true
   end
 
   M.WIN_ON_ENTER = vim.api.nvim_get_current_win()
@@ -85,6 +85,7 @@ function M.neo_zoom()
   vim.api.nvim_set_current_buf(cur_buf)
 
   pin_to_scrolloff()
+  return true
 end
 
 local function setup_vim_commands()


### PR DESCRIPTION
Currently it's not possible to know if the neo_zoom() command skipped execution due to the current buffer being a terminal or the filetype being in the exclusion list. This leads to awkward behavior when using custom configuration, including the custom config example given in the README.

With this change, we can do things like this

```lua
local neozoom = pcall(require, 'neo-zoom')
local NOREF_NOERR_TRUNC = { silent = true, nowait = true }
local cur_buf = nil
vim.keymap.set('n', '<leader>z', function()
  if neozoom.FLOAT_WIN
    and vim.api.nvim_win_is_valid(neozoom.FLOAT_WIN) then
    if neozoom.neo_zoom() then
      vim.api.nvim_set_current_buf(cur_buf) -- Only replace buffer if we actually do a zoom toggle, otherwise weird stuff happens
    end
    return
  end
end, NOREF_NOERR_NOTRUNC)
```