### PR TITLE
Should support `ibhagwan/fzf-lua` functions again (fix #51)

### DIFF
--- a/lua/neo-zoom/init.lua
+++ b/lua/neo-zoom/init.lua
@@ -9,6 +9,18 @@ local zoom_book = {}
 
 
 local function create_autocmds()
+  vim.api.nvim_create_autocmd({ 'WinLeave', }, {
+    group = 'NeoZoom.lua',
+    pattern = '*',
+    callback = function ()
+      if
+        _in_execution
+        or not M.did_zoom()[1]
+        or vim.api.nvim_get_current_win() ~= M.did_zoom()[2]
+      then return end
+      _exit_view = vim.fn.winsaveview()
+    end
+  })
   vim.api.nvim_create_autocmd({ 'WinEnter', }, {
     group = 'NeoZoom.lua',
     pattern = '*',
@@ -20,18 +32,6 @@ local function create_autocmds()
         or vim.api.nvim_get_current_win() == M.did_zoom()[2]
       then return end
       M.neo_zoom()
-    end
-  })
-  vim.api.nvim_create_autocmd({ 'WinLeave', }, {
-    group = 'NeoZoom.lua',
-    pattern = '*',
-    callback = function ()
-      if
-        _in_execution
-        or not M.did_zoom()[1]
-        or vim.api.nvim_get_current_win() ~= M.did_zoom()[2]
-      then return end
-      _exit_view = vim.fn.winsaveview()
     end
   })
 end

--- a/lua/neo-zoom/init.lua
+++ b/lua/neo-zoom/init.lua
@@ -14,8 +14,7 @@ local function create_autocmds()
     pattern = '*',
     callback = function ()
       if
-        _in_execution
-        or not M.did_zoom()[1]
+        not M.did_zoom()[1]
         or vim.api.nvim_get_current_win() ~= M.did_zoom()[2]
       then return end
       _exit_view = vim.fn.winsaveview()
@@ -30,6 +29,7 @@ local function create_autocmds()
         or not M.disable_by_cursor
         or not M.did_zoom()[1]
         or vim.api.nvim_get_current_win() == M.did_zoom()[2]
+        or vim.api.nvim_win_get_config(0).relative ~= ''
       then return end
       M.neo_zoom()
     end

--- a/lua/neo-zoom/init.lua
+++ b/lua/neo-zoom/init.lua
@@ -4,10 +4,24 @@ vim.api.nvim_create_augroup('NeoZoom.lua', { clear = true })
 ---------------------------------------------------------------------------------------------------
 M._presets_delegate = {}
 local _in_execution = false
+local _exit_view = nil
 local zoom_book = {}
 
 
 local function create_autocmds()
+  vim.api.nvim_create_autocmd({ 'WinEnter', }, {
+    group = 'NeoZoom.lua',
+    pattern = '*',
+    callback = function ()
+      if
+        _in_execution
+        or not M.disable_by_cursor
+        or not M.did_zoom()[1]
+        or vim.api.nvim_get_current_win() == M.did_zoom()[2]
+      then return end
+      M.neo_zoom()
+    end
+  })
   vim.api.nvim_create_autocmd({ 'WinLeave', }, {
     group = 'NeoZoom.lua',
     pattern = '*',
@@ -16,10 +30,9 @@ local function create_autocmds()
         _in_execution
         or not M.disable_by_cursor
         or not M.did_zoom()[1]
+        or vim.api.nvim_get_current_win() ~= M.did_zoom()[2]
       then return end
-      if vim.api.nvim_get_current_win() == M.did_zoom()[2] then
-        M.neo_zoom()
-      end
+      _exit_view = vim.fn.winsaveview()
     end
   })
 end
@@ -110,10 +123,9 @@ function M.neo_zoom(opt)
 
     -- try go back first.
     if vim.api.nvim_win_is_valid(zoom_book[z]) then
-      local view = vim.fn.winsaveview()
       vim.api.nvim_win_set_buf(zoom_book[z], vim.api.nvim_win_get_buf(z))
       vim.api.nvim_set_current_win(zoom_book[z])
-      vim.fn.winrestview(view)
+      vim.fn.winrestview(_exit_view)
     end
 
     vim.api.nvim_win_close(z, true)

--- a/lua/neo-zoom/init.lua
+++ b/lua/neo-zoom/init.lua
@@ -28,7 +28,6 @@ local function create_autocmds()
     callback = function ()
       if
         _in_execution
-        or not M.disable_by_cursor
         or not M.did_zoom()[1]
         or vim.api.nvim_get_current_win() ~= M.did_zoom()[2]
       then return end


### PR DESCRIPTION
Summary:

- It's much more reasonable to only make use of both `WinEnter`, and `WinLeave` instead of `BufEnter`. :tada:
- `vim.fn.winsaveview()` will not be called frequently. It's only called upon NeoZoom's floating window on `WinLeave`.
- As title. Now we can call `FzfLua ...` upon NeoZoom's floating window.