### PR TITLE
feat: highlight overrides config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ use {
       -- width_ratio = 0.775,
       -- height_ratio = 0.925,
       -- border = 'double',
+      -- highlight_overrides = {},
       -- disable_by_cursor = true, -- zoom-out/unfocus when you click anywhere else.
       -- exclude_filetypes = { 'lspinfo', 'mason', 'lazy', 'fzf', 'qf' },
       exclude_buftypes = { 'terminal' },
@@ -74,4 +75,26 @@ use {
 }
 ```
 
+#### `highlight_overrides` accepts the following keys:
+
+- fg (or foreground): color name or "#RRGGBB", see note.
+- bg (or background): color name or "#RRGGBB", see note.
+- sp (or special): color name or "#RRGGBB"
+- blend: integer between 0 and 100
+- bold: boolean
+- standout: boolean
+- underline: boolean
+- undercurl: boolean
+- underdouble: boolean
+- underdotted: boolean
+- underdashed: boolean
+- strikethrough: boolean
+- italic: boolean
+- reverse: boolean
+- nocombine: boolean
+- link: name of another highlight group to link to, see :hi-link.
+- default: Don't override existing definition :hi-default
+- ctermfg: Sets foreground of cterm color ctermfg
+- ctermbg: Sets background of cterm color ctermbg
+- cterm: cterm attribute map, like highlight-args. If not set, cterm attributes will match those from the attribute map documented above.
 

--- a/lua/neo-zoom/init.lua
+++ b/lua/neo-zoom/init.lua
@@ -44,6 +44,7 @@ function M.setup(opt)
   M.height_ratio = opt.height_ratio or 0.9
   M.width_ratio = opt.width_ratio or 0.66
   M.border = opt.border or 'double'
+  M.highlight_overrides = opt.highlight_overrides or {}
 
   M.disable_by_cursor = opt.disable_by_cursor
     if M.disable_by_cursor == nil then M.disable_by_cursor = true end
@@ -72,6 +73,7 @@ function M.setup(opt)
               preset.config.height_ratio = preset.config.height_ratio or M.height_ratio
               preset.config.width_ratio = preset.config.width_ratio or M.width_ratio
               preset.config.border = preset.config.border or M.border
+              preset.config.highlight_overrides = preset.config.highlight_overrides or M.highlight_overrides
               return preset
             end
           end
@@ -85,6 +87,7 @@ function M.setup(opt)
             height_ratio = M.height_ratio,
             width_ratio = M.width_ratio,
             border = M.border,
+            highlight_overrides = M.highlight_overrides
           }
         }
       end
@@ -150,6 +153,7 @@ function M.neo_zoom(opt)
   local float_height = math.ceil(editor.height * preset.config.height_ratio + 0.5)
   local float_width = math.ceil(editor.width * preset.config.width_ratio + 0.5)
   local border = preset.config.border
+  local highlight_overrides = preset.config.highlight_overrides
 
   zoom_book[
     vim.api.nvim_open_win(0, true, {
@@ -165,6 +169,8 @@ function M.neo_zoom(opt)
       border = border,
     })
   ] = win_on_zoom
+
+  vim.api.nvim_set_hl(0, 'NormalFloat', highlight_overrides)
 
   vim.api.nvim_set_current_buf(buf_on_zoom)
   if type(preset.callbacks) == 'table' then


### PR DESCRIPTION
Allows to customise highlight properties.
> Highlight definition map, accepts the following keys:
fg (or foreground): color name or "#RRGGBB", see note.
bg (or background): color name or "#RRGGBB", see note.
sp (or special): color name or "#RRGGBB"
blend: integer between 0 and 100
bold: boolean
standout: boolean
underline: boolean
undercurl: boolean
underdouble: boolean
underdotted: boolean
underdashed: boolean
strikethrough: boolean
italic: boolean
reverse: boolean
nocombine: boolean
link: name of another highlight group to link to, see [:hi-link](https://neovim.io/doc/user/syntax.html#%3Ahi-link).
default: Don't override existing definition [:hi-default](https://neovim.io/doc/user/syntax.html#%3Ahi-default)
ctermfg: Sets foreground of cterm color [ctermfg](https://neovim.io/doc/user/syntax.html#ctermfg)
ctermbg: Sets background of cterm color [ctermbg](https://neovim.io/doc/user/syntax.html#ctermbg)
cterm: cterm attribute map, like [highlight-args](https://neovim.io/doc/user/syntax.html#highlight-args). If not set, cterm attributes will match those from the attribute map documented above.

**Use case:** background color is darker by default using `github-nvim-theme`:

```lua
neozoom.setup({
  ...
  highlight_overrides = {
    bg = 'none',
  },
})
```

| before | after |
|--------|------|
| <img width="1465" alt="image" src="https://user-images.githubusercontent.com/27580836/216809948-61a533c0-f8ff-4f11-9f5c-952d9e2a7a43.png"> | <img width="1464" alt="image" src="https://user-images.githubusercontent.com/27580836/216809976-d4152e7c-4d4c-436a-a1ef-c4b9eeda2f5b.png"> |