### PR TITLE
feat(setup): allow custom border values

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ use {
           width = 150,
           height = 0.85,
         },
+        -- NOTE: check :help nvim_open_win() for possible border values.
         -- border = 'double',
       },
       -- exclude_filetypes = { 'lspinfo', 'mason', 'lazy', 'fzf', 'qf' },

--- a/lua/neo-zoom/init.lua
+++ b/lua/neo-zoom/init.lua
@@ -66,7 +66,9 @@ function M.setup(opts)
       -- center as default.
       if type(M.winopts.offset.top) ~= 'number' then M.winopts.offset.top = nil end
       if type(M.winopts.offset.left) ~= 'number' then M.winopts.offset.left = nil end
-    if type(M.winopts.border) ~= 'string' then M.winopts.border = 'double' end
+    if type(M.winopts.border) ~= 'string' and type(M.winopts.border) ~= 'table' then
+      M.winopts.border = 'double'
+    end
   M.exclude_filetypes = U.table_add_values({ 'lspinfo', 'mason', 'lazy', 'fzf' },
     type(opts.exclude_filetypes) == 'table' and opts.exclude_filetypes or {})
   M.exclude_buftypes = U.table_add_values({},


### PR DESCRIPTION
This change adds support for table value types for `border` option, allowing users to create custom border types using array of symbols and following `api.nvim_open_win()` options format.

It will allow users to set custom borders using `{ "╔", "═" ,"╗","║", "╝", "═", "╚", "║" }` format, also allowing to draw only parts of the border by skipping some of the symbols (for example, skipping horizontal ones to maximize vertical space).