### PR TITLE
fix: minimum value of window col is 0

### DIFF
--- a/lua/neo-zoom/init.lua
+++ b/lua/neo-zoom/init.lua
@@ -182,7 +182,7 @@ function M.neo_zoom(opts)
     -- variables.
     ---- center the floating window by default.
     row = U.ratio_to_integer(U.with_fallback(offset.top, U.get_side_ratio(offset.height, editor.height)), editor.height),
-    col = 1 + U.ratio_to_integer(U.with_fallback(offset.left, U.get_side_ratio(offset.width, editor.width)), editor.width),
+    col = U.ratio_to_integer(U.with_fallback(offset.left, U.get_side_ratio(offset.width, editor.width)), editor.width),
     ---- `1` has special meaning for `height`, `width`.
     height = U.ratio_to_integer(offset.height, editor.height, true),
     width = U.ratio_to_integer(offset.width, editor.width, true),


### PR DESCRIPTION
In `:h nvim_open_win()`, the miminum value of window col is 0 in Neovim 0.9.5.
```
    With relative=editor (row=0,col=0) refers to the top-left corner of the
    screen-grid and (row=Lines-1,col=Columns-1) refers to the bottom-right
    corner. Fractional values are allowed, but the builtin implementation
    (used by non-multigrid UIs) will always round down to nearest integer.
```
I'm not sure whether earlier Neovim version has different explanations of row and col.