### PR TITLE
fix: restrict floating windows height to display bottom border

### DIFF
--- a/lua/neo-zoom/utils/init.lua
+++ b/lua/neo-zoom/utils/init.lua
@@ -55,4 +55,19 @@ function M.with_fallback(A, B)
 end
 
 
+function M.get_max_height(value, max, top, border)
+  local border_rows = 2
+  if type(border) == "string" and border == "none" then
+    border_rows = 0
+  elseif type(border) == "string" and border == "shadow" then
+    border_rows = 1
+  end
+  if (value + top + border_rows) > max then
+    return max - top - border_rows
+  else
+    return value
+  end
+end
+
+
 return M


### PR DESCRIPTION
Because the `zindex` of floating window is 5, the bottom border of the windows will be covered by the command line if the bottom border overlaps with the command line (#86).
Neovim automatically adjusts the floating window dimension if the giving col/row/height/width make the floating window exceed the border of the editor. If the `row + height` of the floating window is equal to or greater than the editor height, the bottom border will overlap with the command line.

The PR restricts the floating window bottom border to `editor.height - 1`. Therefore, the bottom border can be correctly displayed.

Another solution is to increase the `zindex` of the floating window. However, command line will be covered by the bottom border. Users cannot see what they typed.